### PR TITLE
chore: add missing repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "contributors": [
     "Cody Persinger <codypersinger@gmail.com> (https://github.com/codynova)"
   ],
+  "repository": "github:pmndrs/use-cannon",
   "license": "MIT",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Note: `github:` postfix could be omitted